### PR TITLE
feat(chat): add error banner with classified messages and retry

### DIFF
--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -24,6 +24,8 @@ When invoked:
 - **Commits**: Conventional Commits (`feat:`, `fix:`, `refactor:`, etc.); exclude generated files (e.g. `routeTree.gen.ts`)
 - **Styling**: Use `cn()` from `@/lib/utils` for conditional class names; `cva()` for variants; no template string interpolation for `className`
 - **React**: Small named components; co-locate under `features/<feature>/`; folder structure for compound components (`ComponentName/index.tsx` + `components/`)
+- **Composition**: Flag anonymous styled `<div>` wrappers — these are imperative (they describe *how* something looks). Prefer named layout components that describe *what* they are (e.g. `<AlertLayout>`, `<AlertBody>`), making the consuming component read as a description of intent. Use the compound component pattern only when the caller genuinely needs dynamic control over what is rendered and in what order; for static layouts, named components are simpler and sufficient.
+- **Markup**: Review HTML structure closely — prefer semantic elements (`<section>`, `<article>`, `<nav>`, `<ul>/<li>`, `<p>`, etc.) over plain `<div>`/`<span>` where the element has meaningful structure or role; flag `<div>` wrappers used purely for layout that could be replaced with CSS (`align-self`, `flex`, etc.)
 - **Comments**: Sparingly; only for non-obvious intent or trade-offs—prefer refactoring over explanatory comments
 
 ## Output format

--- a/.cursor/rules/react-components.mdc
+++ b/.cursor/rules/react-components.mdc
@@ -10,6 +10,31 @@ alwaysApply: false
 - Ensure components have their **own file** by default.
   - The exception is when **small compound components** are clearer co-located in the same file.
 - Extract non-trivial inline UI widgets (e.g. loaders/indicators) into their own named components.
+- **Favour composition over anonymous styled divs.** A `<div className="flex ...">` is imperative — it describes *how* it looks. Replace styled structural wrappers with named layout components that describe *what* they are. Examples:
+  - `<AlertLayout>` — a `role="alert"` container with its border, shadow, and flex layout baked in
+  - `<AlertBody>` — the content column next to the icon
+  - `<AlertMessage>` — the text block for the primary message
+  This makes the consuming component read as a description of intent rather than a stylesheet.
+  ```tsx
+  // Prefer this
+  <AlertLayout>
+    <WarningIcon />
+    <AlertBody>
+      <AlertMessage>{message}</AlertMessage>
+      <RetryButton onClick={reload} />
+    </AlertBody>
+  </AlertLayout>
+
+  // Over this
+  <div role="alert" className="flex items-start gap-3 rounded border ...">
+    <WarningIcon />
+    <div className="flex min-w-0 flex-1 flex-col gap-3">
+      <p className="font-medium text-bright">{message}</p>
+      <button onClick={reload}>Try again</button>
+    </div>
+  </div>
+  ```
+- **Use the compound component pattern only for dynamic composition** — where the caller needs control over what is rendered and in what order. Do not use it for static layouts where the structure is always the same; named layout components are simpler and sufficient there. A compound component is appropriate when different call sites assemble genuinely different combinations of parts.
 - Prefer **co-located UI** under `apps/client/src/features/<feature>/...` for feature-specific components.
 - When a component has **child components**, use a folder structure:
   ```

--- a/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/AlertBody.tsx
+++ b/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/AlertBody.tsx
@@ -1,0 +1,10 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+export const AlertBody = ({
+  children,
+  ...props
+}: ComponentPropsWithoutRef<'div'>) => (
+  <div className="flex min-w-0 flex-1 flex-col gap-3" {...props}>
+    {children}
+  </div>
+);

--- a/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/AlertLayout.tsx
+++ b/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/AlertLayout.tsx
@@ -1,0 +1,15 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+export const AlertLayout = ({
+  children,
+  ...props
+}: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    role="alert"
+    aria-live="assertive"
+    className="flex items-start gap-3 rounded border border-alternate/40 bg-dark px-4 py-3 text-sm text-grey shadow-focus-glow"
+    {...props}
+  >
+    {children}
+  </div>
+);

--- a/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/AlertMessages.tsx
+++ b/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/AlertMessages.tsx
@@ -1,0 +1,10 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+export const AlertMessages = ({
+  children,
+  ...props
+}: ComponentPropsWithoutRef<'div'>) => (
+  <div className="flex flex-col gap-1" {...props}>
+    {children}
+  </div>
+);

--- a/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/RetryButton.tsx
+++ b/apps/client/src/features/chat/ui/components/ChatErrorBanner/components/RetryButton.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@/ui/components/elements/Button';
+
+type RetryButtonProps = {
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+export const RetryButton = ({
+  onClick,
+  disabled,
+  className
+}: RetryButtonProps) => (
+  <Button
+    onClick={onClick}
+    disabled={disabled}
+    width="normal"
+    className={className}
+  >
+    Try again
+  </Button>
+);

--- a/apps/client/src/features/chat/ui/components/ChatErrorBanner/index.test.tsx
+++ b/apps/client/src/features/chat/ui/components/ChatErrorBanner/index.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { formatResetDate, formatRetryTime } from './utils';
+
+import { ChatErrorBanner } from './index';
+
+const user = userEvent.setup();
+
+const mockReload = vi.fn();
+let mockError: Error | null = null;
+let mockKind: 'rate_limit' | 'token_limit' | 'unavailable' | 'unknown' | null =
+  null;
+let mockRetryAt: Date | null = null;
+
+vi.mock('../../context/useChatContext', () => ({
+  useChatStatus: () => ({
+    error: mockError,
+    kind: mockKind,
+    retryAt: mockRetryAt
+  }),
+  useChatActions: () => ({ reload: mockReload })
+}));
+
+beforeEach(() => {
+  mockError = new Error('Test error');
+  mockKind = 'unknown';
+  mockRetryAt = null;
+});
+
+afterEach(() => {
+  mockReload.mockClear();
+});
+
+it('should render nothing when error is null', () => {
+  mockError = null;
+  const { container } = render(<ChatErrorBanner />);
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('should render nothing when kind is null', () => {
+  mockKind = null;
+  const { container } = render(<ChatErrorBanner />);
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+describe('When an error is present with a classified kind', () => {
+  it('should render an alert with the rate_limit message', () => {
+    mockKind = 'rate_limit';
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The AI service is temporarily rate-limited.'
+    );
+  });
+
+  it('should render an alert with the token_limit message', () => {
+    mockKind = 'token_limit';
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The service has reached its usage limit for today.'
+    );
+  });
+
+  it('should render an alert with the unavailable message', () => {
+    mockKind = 'unavailable';
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The AI service is currently unavailable.'
+    );
+  });
+
+  it('should render an alert with the unknown message', () => {
+    mockKind = 'unknown';
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Something went wrong.'
+    );
+  });
+});
+
+it('should show the wait message for token_limit', () => {
+  mockKind = 'token_limit';
+  render(<ChatErrorBanner />);
+
+  expect(screen.getByText('Please try again tomorrow.')).toBeInTheDocument();
+});
+
+it('should show the wait message for unavailable', () => {
+  mockKind = 'unavailable';
+  render(<ChatErrorBanner />);
+
+  expect(
+    screen.getByText('Please try again in a few minutes.')
+  ).toBeInTheDocument();
+});
+
+describe('When rate_limit has a retry time', () => {
+  beforeEach(() => {
+    mockKind = 'rate_limit';
+    mockRetryAt = new Date('2025-03-18T14:30:00Z');
+  });
+
+  it('should show the formatted retry time', () => {
+    const retryAt = new Date('2025-03-18T14:30:00Z');
+    mockRetryAt = retryAt;
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      formatRetryTime(retryAt)
+    );
+  });
+
+  it('should include the "Try again after" text', () => {
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByText(/Try again after/)).toBeInTheDocument();
+  });
+});
+
+describe('When token_limit has a reset date', () => {
+  beforeEach(() => {
+    mockKind = 'token_limit';
+    mockRetryAt = new Date('2025-03-20T00:00:00Z');
+  });
+
+  it('should show the formatted reset date', () => {
+    const retryAt = new Date('2025-03-20T00:00:00Z');
+    mockRetryAt = retryAt;
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      formatResetDate(retryAt)
+    );
+  });
+
+  it('should include the "Estimated reset" text', () => {
+    render(<ChatErrorBanner />);
+
+    expect(screen.getByText(/Estimated reset/)).toBeInTheDocument();
+  });
+});
+
+it('should show the retry button for rate_limit', () => {
+  mockKind = 'rate_limit';
+  render(<ChatErrorBanner />);
+
+  expect(
+    screen.getByRole('button', { name: /try again/i })
+  ).toBeInTheDocument();
+});
+
+it('should not show the retry button for token_limit', () => {
+  mockKind = 'token_limit';
+  render(<ChatErrorBanner />);
+
+  expect(
+    screen.queryByRole('button', { name: /try again/i })
+  ).not.toBeInTheDocument();
+});
+
+it('should show the retry button for unavailable', () => {
+  mockKind = 'unavailable';
+  render(<ChatErrorBanner />);
+
+  expect(
+    screen.getByRole('button', { name: /try again/i })
+  ).toBeInTheDocument();
+});
+
+it('should show the retry button for unknown', () => {
+  mockKind = 'unknown';
+  render(<ChatErrorBanner />);
+
+  expect(
+    screen.getByRole('button', { name: /try again/i })
+  ).toBeInTheDocument();
+});
+
+it('should disable the retry button when retry is not allowed', () => {
+  mockKind = 'rate_limit';
+  mockRetryAt = new Date(Date.now() + 60000);
+  render(<ChatErrorBanner />);
+
+  expect(screen.getByRole('button', { name: /try again/i })).toBeDisabled();
+});
+
+describe('When the user clicks the retry button', () => {
+  it('should call reload', async () => {
+    mockKind = 'unknown';
+    render(<ChatErrorBanner />);
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/src/features/chat/ui/components/ChatErrorBanner/index.tsx
+++ b/apps/client/src/features/chat/ui/components/ChatErrorBanner/index.tsx
@@ -1,0 +1,72 @@
+import { useChatActions, useChatStatus } from '../../context/useChatContext';
+import { WarningIcon } from '../WarningIcon';
+
+import { AlertBody } from './components/AlertBody';
+import { AlertLayout } from './components/AlertLayout';
+import { AlertMessages } from './components/AlertMessages';
+import { RetryButton } from './components/RetryButton';
+import { formatResetDate, formatRetryTime, isRetryAllowed } from './utils';
+
+import type { ChatErrorCode } from '@/server/response/chatErrorCode';
+
+const errorMessages: Record<ChatErrorCode, string> = {
+  rate_limit: 'The AI service is temporarily rate-limited.',
+  token_limit: 'The service has reached its usage limit for today.',
+  unavailable: 'The AI service is currently unavailable.',
+  unknown: 'Something went wrong.'
+};
+
+const waitMessages: Record<ChatErrorCode, string | null> = {
+  rate_limit: null,
+  token_limit: 'Please try again tomorrow.',
+  unavailable: 'Please try again in a few minutes.',
+  unknown: null
+};
+
+export const ChatErrorBanner = () => {
+  const { error, kind, retryAt } = useChatStatus();
+  const { reload } = useChatActions();
+
+  if (!error || !kind) return null;
+
+  const showRetryButton = kind !== 'token_limit';
+  const retryDisabled = !isRetryAllowed(retryAt);
+  const waitMessage = waitMessages[kind];
+
+  return (
+    <AlertLayout>
+      <WarningIcon className="mt-0.5 h-5 w-5 shrink-0" />
+      <AlertBody>
+        <AlertMessages>
+          <p className="font-medium text-bright">{errorMessages[kind]}</p>
+          {waitMessage && <p className="text-grey">{waitMessage}</p>}
+          {kind === 'rate_limit' && retryAt && (
+            <p className="text-grey">
+              Try again after{' '}
+              <span className="font-medium text-primary">
+                {formatRetryTime(retryAt)}
+              </span>
+              .
+            </p>
+          )}
+          {kind === 'token_limit' && retryAt && (
+            <p className="text-grey">
+              Estimated reset:{' '}
+              <span className="font-medium text-primary">
+                {formatResetDate(retryAt)}
+              </span>
+              .
+            </p>
+          )}
+        </AlertMessages>
+        {showRetryButton && (
+          <RetryButton
+            onClick={reload}
+            disabled={retryDisabled}
+            className="self-start"
+          />
+        )}
+      </AlertBody>
+    </AlertLayout>
+  );
+};

--- a/apps/client/src/features/chat/ui/components/ChatErrorBanner/utils.ts
+++ b/apps/client/src/features/chat/ui/components/ChatErrorBanner/utils.ts
@@ -1,0 +1,18 @@
+export function formatRetryTime(date: Date): string {
+  return date.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+export function formatResetDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+export function isRetryAllowed(retryAt: Date | null): boolean {
+  return retryAt === null || retryAt <= new Date();
+}

--- a/apps/client/src/features/chat/ui/components/ChatForm.tsx
+++ b/apps/client/src/features/chat/ui/components/ChatForm.tsx
@@ -13,11 +13,13 @@ export const ChatForm = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const wasLoadingRef = useRef(false);
   const { sendMessage } = useChatActions();
-  const { isLoading } = useChatStatus();
+  const { isLoading, error } = useChatStatus();
+
+  const isBlocked = isLoading || !!error;
 
   const trySend = () => {
     const message = input.trim();
-    if (!message || isLoading) return;
+    if (!message || isBlocked) return;
 
     sendMessage(message);
     setInput('');
@@ -46,7 +48,7 @@ export const ChatForm = () => {
     }
   };
 
-  const canSend = input.trim().length > 0 && !isLoading;
+  const canSend = input.trim().length > 0 && !isBlocked;
 
   return (
     <form onSubmit={handleSubmit} className="border-t border-primary/40 pt-4">
@@ -58,7 +60,7 @@ export const ChatForm = () => {
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Ask about my experience, skills, or projects…"
-          disabled={isLoading}
+          disabled={isBlocked}
           className="h-11 border-0 pr-12 focus:shadow-none focus:outline-none md:h-12"
         />
         <button

--- a/apps/client/src/features/chat/ui/components/Disclaimer/index.tsx
+++ b/apps/client/src/features/chat/ui/components/Disclaimer/index.tsx
@@ -2,7 +2,7 @@
 
 import * as Popover from '@radix-ui/react-popover';
 
-import { WarningIcon } from './components/WarningIcon';
+import { WarningIcon } from '../WarningIcon';
 
 export const Disclaimer = () => (
   <Popover.Root>

--- a/apps/client/src/features/chat/ui/components/WarningIcon.tsx
+++ b/apps/client/src/features/chat/ui/components/WarningIcon.tsx
@@ -1,9 +1,17 @@
-export const WarningIcon = () => (
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export const WarningIcon = ({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<'svg'>) => (
   <svg
     viewBox="0 0 16 16"
-    className="h-6 w-6 text-primary"
     aria-hidden="true"
     focusable="false"
+    className={cn('text-primary', className)}
+    {...props}
   >
     <path
       d="M8 2 L15 14 H1 Z"

--- a/apps/client/src/features/chat/ui/context/useChatContext.tsx
+++ b/apps/client/src/features/chat/ui/context/useChatContext.tsx
@@ -8,9 +8,11 @@ import { createContext, use, useMemo } from 'react';
 
 import { profileToolClient } from '../../ai/tools/profile/client';
 import { rolesToolClient } from '../../ai/tools/roles/client';
+import { classifyChatError } from '../utils/classifyChatError';
 
 import type { ReactNode } from 'react';
 import type { ChatContextType } from '../types/ChatContext.type';
+import type { ChatErrorCode } from '@/server/response/chatErrorCode';
 
 const chatClientOptions = createChatClientOptions({
   connection: fetchServerSentEvents('/api/chat'),
@@ -21,7 +23,10 @@ const chatClientOptions = createChatClientOptions({
 });
 
 type ChatActions = Pick<ChatContextType, 'sendMessage' | 'stop' | 'reload'>;
-type ChatStatus = Pick<ChatContextType, 'isLoading' | 'error'>;
+type ChatStatus = Pick<ChatContextType, 'isLoading' | 'error'> & {
+  kind: ChatErrorCode | null;
+  retryAt: Date | null;
+};
 type ChatMessages = Pick<ChatContextType, 'messages'>;
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -41,9 +46,19 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
     [chat.reload, chat.sendMessage, chat.stop]
   );
 
+  const classification = useMemo(
+    () => (chat.error ? classifyChatError(chat.error) : null),
+    [chat.error]
+  );
+
   const status = useMemo<ChatStatus>(
-    () => ({ isLoading: chat.isLoading, error: chat.error }),
-    [chat.error, chat.isLoading]
+    () => ({
+      isLoading: chat.isLoading,
+      error: chat.error,
+      kind: classification?.kind ?? null,
+      retryAt: classification?.retryAt ?? null
+    }),
+    [chat.error, chat.isLoading, classification]
   );
 
   const messages = useMemo<ChatMessages>(

--- a/apps/client/src/features/chat/ui/index.tsx
+++ b/apps/client/src/features/chat/ui/index.tsx
@@ -5,6 +5,7 @@ import { ChatSection } from './components/ChatSection';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatBody } from './components/ChatBody';
 import { Messages } from './components/Messages';
+import { ChatErrorBanner } from './components/ChatErrorBanner';
 import { ChatForm } from './components/ChatForm';
 import { Disclaimer } from './components/Disclaimer';
 
@@ -19,6 +20,7 @@ export const Chat = () => (
       </ChatHeader>
       <ChatBody>
         <Messages />
+        <ChatErrorBanner />
         <ChatForm />
       </ChatBody>
     </ChatSection>

--- a/apps/client/src/features/chat/ui/utils/classifyChatError.ts
+++ b/apps/client/src/features/chat/ui/utils/classifyChatError.ts
@@ -1,0 +1,41 @@
+import type { ChatErrorCode } from '@/server/response/chatErrorCode';
+
+export type ClassifiedChatError = {
+  kind: ChatErrorCode;
+  retryAt: Date | null;
+};
+
+const DEFAULT_RATE_LIMIT_RETRY_SECONDS = 60;
+
+// TanStack AI client throws: "HTTP error! status: 429 Too Many Requests"
+function parseHttpStatus(message: string): number | null {
+  const match = message.match(/status:\s*(\d{3})/);
+  return match?.[1] ? parseInt(match[1], 10) : null;
+}
+
+function endOfDayUtc(): Date {
+  const d = new Date();
+  d.setUTCHours(23, 59, 59, 999);
+  return d;
+}
+
+export function classifyChatError(error: Error): ClassifiedChatError {
+  const status = parseHttpStatus(error.message);
+
+  if (status === 429) {
+    const retryAt = new Date(
+      Date.now() + DEFAULT_RATE_LIMIT_RETRY_SECONDS * 1000
+    );
+    return { kind: 'rate_limit', retryAt };
+  }
+
+  if (status === 402) {
+    return { kind: 'token_limit', retryAt: endOfDayUtc() };
+  }
+
+  if (status === 503) {
+    return { kind: 'unavailable', retryAt: null };
+  }
+
+  return { kind: 'unknown', retryAt: null };
+}

--- a/apps/client/src/routes/api/chat.ts
+++ b/apps/client/src/routes/api/chat.ts
@@ -3,6 +3,8 @@ import '@tanstack/react-start/server-only';
 import { chat, maxIterations, toServerSentEventsResponse } from '@tanstack/ai';
 import { createFileRoute } from '@tanstack/react-router';
 
+import type { ChatErrorCode } from '@/server/response/chatErrorCode';
+
 import { createErrorResponse } from '@/server/response/error.server';
 import { getApiKey } from '@/server/env/env.server';
 import { getAdapter } from '@/features/chat/server/ai/adapter.server';
@@ -14,11 +16,78 @@ export const Route = createFileRoute('/api/chat')({
   server: { handlers: { POST } }
 });
 
+const DEFAULT_RATE_LIMIT_RETRY_SECONDS = 60;
+
+function classifyProviderError(error: Error): {
+  code: ChatErrorCode;
+  status: number;
+  retryAfterSeconds?: number;
+} {
+  const message = error.message.toLowerCase();
+
+  const isRateLimit =
+    message.includes('rate limit') ||
+    message.includes('rate_limit') ||
+    message.includes('too many requests') ||
+    message.includes('429');
+
+  const isTokenLimit =
+    message.includes('quota') ||
+    message.includes('billing') ||
+    message.includes('usage limit') ||
+    message.includes('credit') ||
+    message.includes('token limit exceeded');
+
+  const isUnavailable =
+    message.includes('unavailable') ||
+    message.includes('overloaded') ||
+    message.includes('503') ||
+    message.includes('service error') ||
+    message.includes('connection');
+
+  const retryAfterSeconds = extractRetryAfter(error);
+
+  // token_limit uses 402 (Payment Required) so the client can distinguish
+  // it from a per-minute rate limit, which uses standard 429.
+  if (isTokenLimit) {
+    return { code: 'token_limit', status: 402 };
+  }
+  if (isRateLimit) {
+    return {
+      code: 'rate_limit',
+      status: 429,
+      retryAfterSeconds: retryAfterSeconds ?? DEFAULT_RATE_LIMIT_RETRY_SECONDS
+    };
+  }
+  if (isUnavailable) {
+    return { code: 'unavailable', status: 503 };
+  }
+
+  return { code: 'unknown', status: 500 };
+}
+
+function extractRetryAfter(error: Error): number | undefined {
+  const match = error.message.match(/retry.?after[:\s]+(\d+)/i);
+  if (match?.[1]) return parseInt(match[1], 10);
+
+  // Some provider SDKs attach the raw response as a property
+  const raw = (error as unknown as Record<string, unknown>).response;
+  if (raw instanceof Response) {
+    const header = raw.headers.get('Retry-After');
+    if (header) return parseInt(header, 10);
+  }
+
+  return undefined;
+}
+
 export async function POST({ request }: { request: Request }) {
   const { apiKey, apiKeyName } = getApiKey();
 
   if (!apiKey) {
-    return createErrorResponse(new Error(`${apiKeyName} not configured`));
+    return createErrorResponse(new Error(`${apiKeyName} not configured`), {
+      code: 'unavailable',
+      status: 503
+    });
   }
 
   const { messages, conversationId } = await request.json();
@@ -38,8 +107,8 @@ export async function POST({ request }: { request: Request }) {
 
     return toServerSentEventsResponse(stream);
   } catch (error) {
-    return createErrorResponse(
-      error instanceof Error ? error : new Error('An error occurred')
-    );
+    const err = error instanceof Error ? error : new Error('An error occurred');
+    const classification = classifyProviderError(err);
+    return createErrorResponse(err, classification);
   }
 }

--- a/apps/client/src/server/response/chatErrorCode.ts
+++ b/apps/client/src/server/response/chatErrorCode.ts
@@ -1,0 +1,5 @@
+export type ChatErrorCode =
+  | 'rate_limit'
+  | 'token_limit'
+  | 'unavailable'
+  | 'unknown';

--- a/apps/client/src/server/response/error.server.ts
+++ b/apps/client/src/server/response/error.server.ts
@@ -1,8 +1,25 @@
-export const createErrorResponse = (error: Error) => {
-  return new Response(
-    JSON.stringify({
-      error: error.message
-    }),
-    { status: 500, headers: { 'Content-Type': 'application/json' } }
-  );
+import type { ChatErrorCode } from './chatErrorCode';
+
+type ErrorResponseOptions = {
+  code?: ChatErrorCode;
+  status?: number;
+  retryAfterSeconds?: number;
+};
+
+export const createErrorResponse = (
+  error: Error,
+  {
+    code = 'unknown',
+    status = 500,
+    retryAfterSeconds
+  }: ErrorResponseOptions = {}
+) => {
+  const body: Record<string, unknown> = { error: error.message, code };
+  if (retryAfterSeconds !== undefined) {
+    body.retryAfterSeconds = retryAfterSeconds;
+  }
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
 };


### PR DESCRIPTION
- Add ChatErrorBanner with rate_limit, token_limit, unavailable, unknown handling
- Classify errors via chatErrorCode, show wait messages and retry timing
- Extract AlertLayout, AlertBody, AlertMessages, RetryButton components
- Move WarningIcon to shared location for reuse
- Add Vitest tests for ChatErrorBanner

Made-with: Cursor